### PR TITLE
Fix cleaning up lockfiles _after_ generation and on error

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,44 @@
 It makes a `*.lock` file (based on the name of the entry point) while rollup is compiling that file.
 
 That's it!
+
+### Usage:
+
+
+#### Simple usage
+
+Lockfiles will be generated based on the input name(s), in the `dir` directory.
+
+```
+// rollup.config.js
+import typescript from 'rollup-plugin-typescript';
+
+export default {
+  input: './main.ts',
+  plugins: [
+    lockfile({
+      dir: '/path/to/output/directory'
+    })
+  ]
+}
+```
+
+#### Advanced usage
+
+The full filename can be configured by passing `name`
+
+```
+// rollup.config.js
+import typescript from 'rollup-plugin-typescript';
+
+export default {
+  input: './main.ts',
+  plugins: [
+    lockfile({
+      name(name) {
+        return myCustomLockfileFilenameDeterminer(name)
+      }
+    })
+  ]
+}
+```


### PR DESCRIPTION
This PR modifies the plugin in three ways:

1. We reset the `lockfiles = {}` object for each fresh build
2. We use the `writeBundle` hook instead of `generateBundle`. This hook is called once _after_ files are actually written, which avoids us removing lockfiles before files are written to disk.
3. We also delete all lockfiles if there is an error in the build, by using the `buildEnd` hook.

`writeBundle` and `buildEnd` don't have access to the same `bundles` variable that `generateBundles` had, but I don't think that's important. I think it's simpler just to delete all lockfiles when we are done with the full build.