### PR TITLE
Provide a data argument to `fs.writeFileSync(...)`.

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ module.exports = function lockfile({ dir = '', name = name => join(dir, basename
       for(const file of input) {
         let lockfile = lockfiles[basename(file)] = name(file)
         mkdirSync(dirname(lockfile), { recursive: true })
-        writeFileSync(lockfile)
+        writeFileSync(lockfile, "")
       }
     },
     buildEnd(error) {


### PR DESCRIPTION
Currently no `data` argument is passed to `writeFileSync`. Until Node 14 this caused the literal string "undefined" to be written to the lockfile, but from Node 14 onward it is an error.