### PR TITLE
Check lockfiles exist before deleting them.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,11 +1,13 @@
 const {join, basename, dirname} = require('path')
-const {mkdirSync, writeFileSync, unlinkSync} = require('fs')
+const {existsSync, mkdirSync, writeFileSync, unlinkSync} = require('fs')
 module.exports = function lockfile({ dir = '', name = name => join(dir, basename(name) + '.lock')}) {
   let lockfiles = {}
 
   const deleteAllLockfiles = () => {
     for (const [name, file] of Object.entries(lockfiles)) {
-      unlinkSync(file)
+      if (existsSync(file)) {
+        unlinkSync(file)
+      }
     }
   }
 


### PR DESCRIPTION
This prevents errors that occur before all lockfiles have been created from being masked by an error that a lockfile couldn't be deleted because it doesn't exist.